### PR TITLE
feat: 3ジャンル視聴達成でバッジを付与するミッションの機能を追加

### DIFF
--- a/missions/services.py
+++ b/missions/services.py
@@ -2,7 +2,16 @@ from movies.models import UserMovieRecord
 from missions.models import Mission, UserMission, UserBatch, Batch
 from django.utils.timezone import now
 
+# ミッション達成判定に使用する対象ジャンルのリスト
+TARGET_GENRE_NAMES = [
+    "アクション映画", "アドベンチャー映画", "SF映画",
+    "ミステリー映画", "恋愛映画", "コメディ映画",
+    "ファンタジー映画", "サスペンス映画", "ファンタジー", "アドベンチャー"
+]
+
 class MissionService:
+
+    #「3本の映画視聴達成」のミッションバッジ付与処理
     @staticmethod
     def check_and_complete_mission(user, mission_title):
         mission = Mission.objects.get(title=mission_title)
@@ -21,6 +30,7 @@ class MissionService:
 
         return False, "まだミッション達成に必要な視聴数に到達していません"
 
+
     @staticmethod
     def grant_batch_for_mission(user, mission_title):
         mission = Mission.objects.get(title=mission_title)
@@ -32,3 +42,34 @@ class MissionService:
 
         if mission.batch:
             UserBatch.objects.get_or_create(user=user, batch=mission.batch)
+
+
+    #映画の記録ジャンルが3種類以上なら「3ジャンル制覇」バッジを付与
+    @staticmethod
+    def check_and_assign_genre_badge(user):
+        mission = Mission.objects.get(title="3ジャンル制覇")
+
+        user_genres = Genre.objects.filter(
+            usermovierecord__user=user,
+            usermovierecord__is_deleted=False
+        ).distinct()
+
+        matched_genres = [
+            genre.name for genre in user_genres
+            if genre.name in TARGET_GENRE_NAMES
+        ]
+
+        if len(set(matched_genres)) >= 3:
+            user_mission, created = UserMission.objects.get_or_create(user=user, mission=mission)
+
+            if created or not user_mission.is_completed:
+                user_mission.is_completed = True
+                user_mission.completed_at = now()
+                user_mission.save()
+
+            if mission.batch:
+                 UserBatch.objects.get_or_create(user=user, badge=mission.batch)
+
+            return True, "ミッションを達成しました！"
+
+        return False, "まだ対象ジャンルが3種類に到達していません"


### PR DESCRIPTION
## 概要  
ユーザーが異なるジャンルの映画を3種類以上視聴した場合に、「3ジャンル制覇」
バッジを1度だけ自動付与する処理を実装しました。
視聴数だけでなく「視聴ジャンルの幅」を可視化することで、より多様な映画体験を促すのが目的です。

## 変更内容
- MissionService.check_and_assign_genre_badge(user) を作成
  (ユーザーが記録したジャンル数を確認し、バッジを1回だけ付与)

- UserMovieRecord の post_save シグナル内で上記サービスを呼び出す処理を追加

- すでに付与済みの場合は再付与されないよう制御

## 動作確認手順
1. 映画を検索する
    * ホーム画面や映画検索ページで、キーワードを入力して検索ボタンをクリック
    * 画面には該当する映画の一覧が表示されます。
    
2. 映画の詳細登録（ポスタークリック）
    * 見つかった映画のポスターをクリック
    * システムが自動で映画の基本情報を取得し、記録フォームへ遷移します。
    
3. 映画を記録（ジャンルを含む）
    * 評価や感想を入力して「登録ボタン」を押下
    * このタイミングで、ユーザーが過去に登録したジャンルを含め
     “合計3種類以上のジャンル”を記録しているかを自動チェック
     
4. 3ジャンル以上ならバッジ付与
    * もし3種類以上のジャンルが登録されていれば「3ジャンル制覇バッジ」が
    　自動で付与
    * バッジ一覧画面（またはマイページ）に「3ジャンル制覇バッジ」が
       表示されていることを確認できます。

## スクリーンョット
<img width="1000" alt="スクリーンショット 2025-03-29 0 10 15" src="https://github.com/user-attachments/assets/b6cd55ce-69c4-4f63-914c-24db8a52f4bd" />

3種類以上のジャンルを登録すると、自動で「3ジャンル制覇」バッジが付与される様子

## 関連Issue
Closes #3
