### PR TITLE
test: 「3ジャンル制覇」バッジ付与処理のユニットテスト（TC01〜TC05）を追加

### DIFF
--- a/missions/tests/test_services.py
+++ b/missions/tests/test_services.py
@@ -134,3 +134,23 @@ class TestMissionService(TestCase):
         self.assertFalse(UserBatch.objects.filter(user=self.user, batch=self.batch_3_genres).exists())
 
 
+    # 4.ジャンルデータが含まれてないデータ登録の時バッチデータは含まれない
+    def test_no_batch_when_movies_have_no_genre(self):
+        with transaction.atomic():
+            for i in range(3):
+                UserMovieRecord.objects.create(
+                    user=self.user,
+                    title=f"Movie No Genre {i+1}",
+                    rating="5",
+                    date_watched=now(),
+                    poster=create_dummy_image()
+                )
+
+            success, message = MissionService.check_and_assign_genre_batch(self.user)
+
+            self.assertFalse(success, "ジャンルなしでもバッジが付与されないことを確認")
+            self.assertEqual(message, "まだ対象ジャンルが3種類に到達していません", "適切なメッセージが返ること")
+            self.assertFalse(UserMission.objects.filter(user=self.user, mission=self.mission_3_genres).exists(), "UserMission が作成されていないこと")
+            self.assertFalse(UserBatch.objects.filter(user=self.user, batch=self.batch_3_genres).exists(), "UserBatch も作成されていないこと")
+
+

--- a/missions/tests/test_services.py
+++ b/missions/tests/test_services.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.utils.timezone import now
 from django.utils import timezone
-from movies.models import UserMovieRecord
+from movies.models import UserMovieRecord, Genre
 from missions.models import Mission, UserMission, Batch, UserBatch
 from missions.services import MissionService
 from PIL import Image
@@ -24,29 +24,49 @@ class TestMissionService(TestCase):
         self.user = User.objects.create_user(username="testuser", password="password")
 
         # 「3本の映画達成」バッジ & ミッション
-        self.batch_3_movies = Batch.objects.create(name="3本の映画達成バッジ", description="3本の映画を視聴達成")
+        self.batch_3_movies = Batch.objects.create(
+            name="3本の映画達成バッジ", 
+            description="3本の映画を視聴達成",
+            icon=create_dummy_image()
+        )
         self.mission_3_movies = Mission.objects.create(
             title="3本の映画達成",
-            description="3本の映画を視聴する。",
+            description="3本の映画を視聴する",
             criteria={"min_watch_count": 3},
             batch=self.batch_3_movies
         )
 
         # 「1日3本の映画視聴達成」バッジ & ミッション
-        self.batch_3_movies_day = Batch.objects.create(name="1日3本の映画視聴達成バッジ", description="1日に3本の映画を視聴達成")
+        self.batch_3_movies_day = Batch.objects.create(
+            name="1日3本の映画視聴達成バッジ", 
+            description="1日に3本の映画を視聴達成",
+            icon=create_dummy_image()
+        )
         self.mission_3_movies_day = Mission.objects.create(
             title="1日3本の映画視聴達成",
-            description="1日で3本の映画を視聴する。",
+            description="1日で3本の映画を視聴する",
             criteria={"min_watch_count": 3, "same_day": True},
             batch=self.batch_3_movies_day
         )
-
         today = now().date()
         UserMovieRecord.objects.bulk_create([
             UserMovieRecord(user=self.user, title="Movie 1", date_watched=today, rating="5", poster=create_dummy_image()),
             UserMovieRecord(user=self.user, title="Movie 2", date_watched=today, rating="5", poster=create_dummy_image()),
             UserMovieRecord(user=self.user, title="Movie 3", date_watched=today, rating="5", poster=create_dummy_image()),
         ])
+
+        # 「3ジャンル制覇」バッジ & ミッション
+        self.batch_3_genres = Batch.objects.create(
+            name="３ジャンル制覇バッジ",
+            description="3ジャンル以上の映画視聴を達成する",
+            icon=create_dummy_image()
+        )
+        self.mission_3_genres = Mission.objects.create(
+            title="３ジャンル制覇", 
+            description="3つ以上の異なるジャンル映画の視聴を達成する",
+            criteria={"type": "genre_count", "value": 3},
+            batch=self.batch_3_genres
+        )
 
     #「3本の映画達成」ミッションを満たした時の検証
     def test_mission_is_completed_when_3_movies_watched(self):
@@ -67,3 +87,27 @@ class TestMissionService(TestCase):
             self.assertEqual(message, "ミッションを達成しました！", "ミッション達成時のメッセージが期待値と異なります")
             self.assertTrue(UserMission.objects.filter(user=self.user, mission=self.mission_3_movies_day).exists(), "UserMission が正しく作成されていることを確認してください")
             self.assertTrue(UserBatch.objects.filter(user=self.user, batch=self.batch_3_movies_day).exists(), "ミッション達成後にバッジが正しく付与されていることを確認してください")
+
+
+    # 「3ジャンル制覇」ミッションを満たした時の検証 
+    # 1.異なる3ジャンルでバッジが付与されることを検証するテスト
+    def test_check_and_assign_genre_batch(self):
+        with transaction.atomic():
+            genre_names = ["アクション", "コメディ", "恋愛"]
+            for i, genre_name in enumerate(genre_names):
+                genre = Genre.objects.create(name=genre_name)
+                record = UserMovieRecord.objects.create(
+                    user=self.user,
+                    title=f"Movie {i+1}",
+                    rating="5",
+                    date_watched=now(),
+                    poster=create_dummy_image()
+                )   
+                record.genres.add(genre)
+
+            success, message = MissionService.check_and_assign_genre_batch(self.user)
+
+            self.assertTrue(success)
+            self.assertEqual(message, "ミッションを達成しました！")
+            self.assertTrue(UserMission.objects.filter(user=self.user, mission=self.mission_3_genres).exists())
+            self.assertTrue(UserBatch.objects.filter(user=self.user, batch=self.batch_3_genres).exists())


### PR DESCRIPTION
### 概要
「3ジャンル制覇」バッジの自動付与処理に関するユニットテストを5ケース（TC01〜TC05）追加しました。  
ユーザーがジャンルの異なる映画を視聴したときに、バッジが正しく付与／未付与されるかを検証しています。

---

### テスト目的
- 条件を満たす場合にのみ `UserMission` / `UserBatch` が作成されることを保証
- 条件未達成時・バッジ保持済みのケースでも副作用が発生しないことを確認
- 処理の堅牢性と再現性を担保し、今後のリファクタや仕様変更時にも信頼性を保つため

---

### テストケース一覧（TC01〜TC05）

| テストID | 条件 | 期待される結果 |
|----------|------|----------------|
| TC01 | 異なる3ジャンル視聴 | バッジ付与あり、UserMission/Batch作成あり |
| TC02 | 同一ジャンル3本視聴 | バッジ付与なし、UserMission/Batch作成なし |
| TC03 | すでにバッジ保持済み | バッジ再付与なし、UserBatchは1件のまま |
| TC04 | ジャンル未設定映画を視聴 | エラーなし、バッジ付与なし |
| TC05 | 2ジャンルのみ視聴 | バッジ付与なし、副作用なし（UserMission/Batchなし） |

---

### Doneの定義への対応
- 全テスト green（成功）で通過済み
- 条件達成時の正常動作と、未達成時の副作用抑制の両方を確認済み
- `UserBatch` / `UserMission` の作成件数もassertで明示

---

### 実行手順（ローカル確認用）

```bash
(env) nakayakenta@nakayakntanoMBP MovieChallenge % pytest missions/tests/test_services.py

===================================================================== test session starts =====================================================================
platform darwin -- Python 3.11.6, pytest-8.3.4, pluggy-1.5.0
django: version: 5.1, settings: MovieChallenge.settings (from ini)
rootdir: /Users/nakayakenta/Desktop/portfolio/MovieChallenge
configfile: pytest.ini
plugins: django-4.9.0
collected 7 items                                                                                                                                             

missions/tests/test_services.py .......                                                                                                                 [100%]

====================================================================== 7 passed in 7.41s ======================================================================

### 実行結果
全7件のテストが green（成功）で通過しています。  
うち5件は「3ジャンル制覇」ミッションに関連したテストで、残りの2件は他のミッション（「3本視聴」「1日3本視聴」）のバッジ付与テストです。

