### PR TITLE
[レビュー機能②] レビュー一覧表示（他ユーザー含む）の実装対応

### DIFF
--- a/movies/views.py
+++ b/movies/views.py
@@ -94,6 +94,13 @@ class MovieRecordDetailView(LoginRequiredMixin, DetailView):
         }
 
         context["movie_data"] = movie_data
+
+        movie = self.get_object()
+
+        # 他のユーザーのレビューを取得（ユーザー名・内容・日付含む）
+        other_reviews = Review.objects.filter(movie=movie).exclude(user=self.request.user).order_by("created_at")
+        context["other_reviews"] = other_reviews
+
         return context
 
 # ユーザーによる映画レビューの投稿ビュー

--- a/movies/views.py
+++ b/movies/views.py
@@ -103,10 +103,20 @@ class ReviewPageView(CreateView):
     template_name = "movies/movie_review.html"
     success_url = "/thanks/"
 
+    def dispatch(self, request, *args, **kwargs):
+        self.movie = get_object_or_404(UserMovieRecord, pk=kwargs["pk"])
+        return super().dispatch(request, *args, **kwargs)
+
     def form_valid(self, form):
         form.instance.user = self.request.user
-        form.instance.movie = get_object_or_404(UserMovieRecord, pk=self.kwargs["movie_pk"])
+        form.instance.movie = self.movie
         return super().form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["movie"] = self.movie 
+        return context
+
     
 
 # 映画情報の取得検索

--- a/templates/movies/movie_record_detail.html
+++ b/templates/movies/movie_record_detail.html
@@ -62,6 +62,21 @@
         </div>
     </div>
 
+    <h3>他のユーザーのレビュー</h3>
+    {% if other_reviews %}
+        <ul>
+            {% for review in other_reviews %}
+            <li>
+                <strong>{{ review.user.username }}</strong>：{{ review.content }}<br>
+                <small>{{ review.created_at|date:"Y年m月d日 H:i" }}</small>
+            </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>この映画にはまだ他のユーザーのレビューがありません。</p>
+    {% endif %}
+
+
     <div class="container text-center mb-4">
         <button type="button" class="btn-new" onclick="location.href='{% url 'movies:create' %}'">新規作成</button>
     </div>

--- a/templates/movies/movie_record_detail.html
+++ b/templates/movies/movie_record_detail.html
@@ -55,7 +55,7 @@
                     {% endif %}
                     <div class="text-center">
                         <a href="{% url 'movies:delete' pk=record.pk %}" class="btn btn-danger">削除</a>
-                        <a href ="{% url 'movies:review' %}" class="btn btn-primary">レビューを書く</a>
+                        <a href="{% url 'movies:review' record.pk %}" class="btn btn-primary">レビューを書く</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## 概要  
ユーザーが投稿内容のレビューの内容を確認できるように対応しました。
レビュー内容は自分以外の投稿しか表示できないように進めました。

## 実装内容
-映画詳細ページの下にユーザーのレビューを設定

## 動作確認手順,スクリーンショット
1. 詳細ページに移動し、他のユーザーからレビューがあれば、「ユーザー名」、「コメント内容」、
　「コメント投稿日時」の表示

<img width="1431" alt="スクリーンショット 2025-04-09 11 03 42" src="https://github.com/user-attachments/assets/a542fdd3-65f9-4025-991d-e6e1e5f41aa1" />


## 今後対応予定（TODO）
- [レビュー機能③] 評価（★）の表示
- [レビュー機能④] 編集・削除機能の追加
- [レビュー機能⑤] いいね機能

## 関連Issue
Closes #9
