### PR TITLE
【レビュー機能④】いいね機能の実装 (Ajax対応)

### DIFF
--- a/movies/views.py
+++ b/movies/views.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import ListView, CreateView, DeleteView, UpdateView, DetailView
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseForbidden, JsonResponse
 from django.urls import reverse_lazy
-from movies.models import UserMovieRecord, Genre, Review
+from movies.models import UserMovieRecord, Genre, Review, Like
 from missions.models import Batch, UserBatch
 from .forms import MovieRecordForm, MovieSearchForm, UserReviewForm
 from django.views import View
@@ -138,13 +138,16 @@ class ReviewLikeView(View):
         user = request.user
 
         like = Like.objects.filter(user=user, review=review).first()
+        liked = False
 
         if like:
             like.delete()
         else:
             Like.objects.create(user=user, review=review, movie=review.movie)
-        return redirect("movies:detail", pk=review.movie.pk)
+            liked = True
 
+        count = review.like_set.count()
+        return JsonResponse({"liked": liked, "count": count})
 
 # 映画情報の取得検索
 class MovieSearchView(TemplateView):

--- a/static/js/movies/review_like.js
+++ b/static/js/movies/review_like.js
@@ -1,15 +1,55 @@
 document.addEventListener("DOMContentLoaded", function () {
-    console.log("DOMが読み込まれました");
-  
-    const buttons = document.querySelectorAll(".like-button");
-    console.log("ボタンの数:", buttons.length);  // ← ここで0ならセレクタが間違い
-  
-    buttons.forEach(button => {
-      button.addEventListener("click", function(e) {
-        e.preventDefault();
-        const reviewId = button.dataset.reviewId;
-        console.log("レビューID:", reviewId);
-      });
+
+  buttons.forEach(button => {
+    button.addEventListener("click", async function (e) {
+      e.preventDefault();
+
+      const reviewId = button.dataset.reviewId;
+
+      try {
+        const response = await fetch(`/review_like/${reviewId}/`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": getCookie("csrftoken"),
+          },
+          body: JSON.stringify({}),
+        });
+
+        if (!response.ok) {
+          throw new Error(`レスポンスステータス: ${response.status}`);
+        }
+
+        const data = await response.json();
+        console.log("サーバーからのレスポンス:", data);
+
+        // DOM更新処理（❤️↔🤍 切り替え + カウント更新）
+        if (data.liked) {
+          button.querySelector(".icon").textContent = "❤️";
+        } else {
+          button.querySelector(".icon").textContent = "🤍";
+        }
+        button.querySelector(".count").textContent = data.count;
+        
+        } catch (error) {
+        console.error("fetchエラー:", error.message);
+      }
     });
   });
-  
+});
+
+// DjangoのCSRFトークンを取得する関数
+function getCookie(name) {
+  let cookieValue = null;
+  if (document.cookie && document.cookie !== "") {
+    const cookies = document.cookie.split(";");
+    for (let i = 0; i < cookies.length; i++) {
+      const cookie = cookies[i].trim();
+      if (cookie.substring(0, name.length + 1) === name + "=") {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}

--- a/static/js/movies/review_like.js
+++ b/static/js/movies/review_like.js
@@ -1,0 +1,15 @@
+document.addEventListener("DOMContentLoaded", function () {
+    console.log("DOMが読み込まれました");
+  
+    const buttons = document.querySelectorAll(".like-button");
+    console.log("ボタンの数:", buttons.length);  // ← ここで0ならセレクタが間違い
+  
+    buttons.forEach(button => {
+      button.addEventListener("click", function(e) {
+        e.preventDefault();
+        const reviewId = button.dataset.reviewId;
+        console.log("レビューID:", reviewId);
+      });
+    });
+  });
+  

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,11 +1,16 @@
+{% load static %}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}映画鑑賞チャレンジアプリ{% endblock %}</title>
-    {% load static %}
-    <link rel="stylesheet" href="{% static 'css/styles.css' %}">
+    <link rel="stylesheet" href="{% static 'css/base/styles.css' %}?v={{ STATIC_VERSION }}">
+    <link rel="stylesheet" href="{% static 'css/users/home/styles.css' %}">
+    <link rel="stylesheet" href="{% static 'css/base/missions/styles.css' %}">
+    <link rel="stylesheet" href="{% static 'css/base/movies/styles.css' %}">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
     <header>
@@ -16,8 +21,10 @@
         <div class="header-nav">
             <nav>
               <ul>
-                <li><a href="{% url 'home' %}">ホーム</a></li>
-                <li><a href="{% url 'profile' %}">プロフィール</a></li>
+                <li><a href="{% url 'movies:home' %}">ホーム</a></li>
+                <li><a href="{% url 'users:logout' %}">ログアウト</a></li>
+                <li><a href="{% url 'missions:user_batch_list' %}">バッチ一覧</a></li>
+                <li><a href="{% url 'users:progress_goal_create' %}">目標管理</a></li>
               </ul>
             </nav>
           </div>
@@ -28,9 +35,12 @@
     </main>
 
     <footer>
-        <div class="container">
+        <div class="container text-center">
             <p>© 2024 サイト名. All rights reserved.</p>
         </div>
     </footer>
+    
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script src="{% static 'js/movies/review_like.js' %}?v={{ STATIC_VERSION }}"></script>
 </body>
 </html>

--- a/templates/movies/movie_record_detail.html
+++ b/templates/movies/movie_record_detail.html
@@ -74,12 +74,14 @@
                 <button type="submit"
                         class="btn btn-outline-primary btn-sm like-button"
                         data-review-id="{{ review.id }}">
-                    {% if review.is_liked_by_user %}
-                        ❤️
-                    {% else %}
-                        🤍
-                    {% endif %}
-                    {{ review.like_set.count }}
+                    <span>
+                        {% if review.is_liked_by_user %}
+                            ❤️
+                        {% else %}
+                            🤍
+                        {% endif %}
+                    </span>
+                    <span class="count">{{ review.like_set.count }}</span>  
                 </button>
             </form>
             {% endfor %}

--- a/templates/movies/movie_record_detail.html
+++ b/templates/movies/movie_record_detail.html
@@ -71,7 +71,9 @@
 
             <form method="POST" action="{% url 'movies:review_like' review.pk %}">
                 {% csrf_token %}
-                <button type="submit" class="btn btn-outline-primary btn-sm">
+                <button type="submit"
+                        class="btn btn-outline-primary btn-sm like-button"
+                        data-review-id="{{ review.id }}">
                     {% if review.is_liked_by_user %}
                         ❤️
                     {% else %}


### PR DESCRIPTION
## 概要  
レビュー詳細画面において、「いいね」ボタンのクリックをAjax（fetch）対応とし、ページリロードなしでトグル切り替えとカウント更新が可能な仕組みを実装しました。

## 実装内容

-.like-button クラスのボタンに対し、クリックイベントをJavaScriptで付与

-fetchを用いた非同期POST通信により、サーバーへいいね状態を送信

-Django側では JsonResponse で liked 状態と count（いいね数）を返却

-フロントエンドで ❤️ / 🤍 アイコンと .count 表示を更新する処理を実装

-CSRFトークンにも対応し、安全な通信を確保

## 動作確認手順
1.他ユーザーのレビューがある映画詳細ページにアクセス

2.「🤍」ボタンをクリック → 「❤️」に切り替わり、カウントが+1

3.もう一度クリック → 「🤍」に戻り、カウントが-1

4.ページを再読み込みしても状態が保持されていることを確認

## スクリーンショット

1.他ユーザーのレビューがある映画詳細ページにアクセス
<img width="722" alt="スクリーンショット 2025-04-17 10 07 31" src="https://github.com/user-attachments/assets/b3288dde-d51f-45c9-a86d-93625eb4a446" />


2.「🤍」ボタンをクリック →  {"liked": true,  "count": 1}
<img width="962" alt="スクリーンショット 2025-04-17 10 13 37" src="https://github.com/user-attachments/assets/dd07815c-ada3-480d-8993-77fc0ee8f365" />


3.もう一度クリック →  {"liked": false,  "count": 0}
<img width="965" alt="スクリーンショット 2025-04-17 10 17 30" src="https://github.com/user-attachments/assets/3881af0d-95e5-4730-aac9-b3c4648f0f4d" />

4.ページを再読み込みしても状態が保持されていることを確認
<img width="1422" alt="スクリーンショット 2025-04-17 10 18 25" src="https://github.com/user-attachments/assets/0ccd7792-feb4-4c00-add1-74d5219f4e80" />


## 現状の課題・制限
liked と count のレスポンスは 正しく取得＆処理できています（console確認済）

しかし、HTML構造の都合により、ボタン内のlikeカウントが即時表示に反映されないケースがあります

現在は ページをリロードすれば正常に反映される 状況です

また、ボタンを直接クリックせずURLを開いた場合（GETアクセス）は 405エラー が出るため、こちらもUI設計上の考慮対象


## 関連Issue
Closes #14
