### PR TITLE
Feature/14 review like ajax toggle fix UI

### DIFF
--- a/movies/urls.py
+++ b/movies/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import UserMovieListView, MovieSearchView, MovieRecordDetailView, ReviewPageView, ThanksPageView, ReviewLikeView, MovieRecordCreateView, MovieRecordDeleteView, MovieRecordEditView, 
+from .views import UserMovieListView, MovieSearchView, MovieRecordDetailView, ReviewPageView, ThanksPageView, ReviewLikeView, MovieRecordCreateView, MovieRecordDeleteView, MovieRecordEditView
 from . import views
 
 app_name = 'movies'
@@ -9,9 +9,9 @@ urlpatterns = [
     path('search/', MovieSearchView.as_view(), name='movie_search'),
     path('movie_create/', views.create_movie_record, name='movie_create'),
     path('detail/<int:pk>/',MovieRecordDetailView.as_view(), name='detail'),
-    path('review/', ReviewPageView.as_view(), name='review'),
+    path('review/<int:pk>/', ReviewPageView.as_view(), name='review'),
     path('thanks/', ThanksPageView.as_view(), name='thanks'),
-    path('review_like/<int:pk>', ReviewLikeView.as_view(), name='review_like'),
+    path('review_like/<int:pk>/', ReviewLikeView.as_view(), name='review_like'),
     path('create/',MovieRecordCreateView.as_view(), name="create"),
     path('delete/<int:pk>/',MovieRecordDeleteView.as_view(), name="delete"),
     path('edit/<int:pk>/', MovieRecordEditView.as_view(), name='edit'),

--- a/static/js/movies/review_like.js
+++ b/static/js/movies/review_like.js
@@ -2,15 +2,14 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // .like-buttonが複数あることを想定して全取得
   const buttons = document.querySelectorAll(".like-button")
-
   buttons.forEach(button => {
     button.addEventListener("click", async function (e) {
       e.preventDefault();
-
+      
       const reviewId = button.dataset.reviewId;
 
       try {
-        const response = await fetch(`/review_like/${reviewId}/`, {
+        const response = await fetch(`/movies/review_like/${reviewId}/`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -25,6 +24,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const data = await response.json();
         console.log("サーバーからのレスポンス:", data);
+        
 
         // DOM更新処理（❤️↔🤍 切り替え + カウント更新）
         if (data.liked) {

--- a/static/js/movies/review_like.js
+++ b/static/js/movies/review_like.js
@@ -1,5 +1,8 @@
 document.addEventListener("DOMContentLoaded", function () {
 
+  // .like-buttonが複数あることを想定して全取得
+  const buttons = document.querySelectorAll(".like-button")
+
   buttons.forEach(button => {
     button.addEventListener("click", async function (e) {
       e.preventDefault();


### PR DESCRIPTION
### 概要
レビューの「いいね」機能をAjax対応し、ページリロードなしでトグル動作とカウント更新が反映されるように改善しました。

### 改善の背景
従来はフォーム送信→ページリロードによって状態更新しており、UXにラグが生じていました。
また、fetchでPOST送信する際に、Django側のルーティングとURL構造が一致せず、405エラーが発生していました。

### 主な対応
- JavaScript側のfetch URLを `/movies/review_like/<int:pk>/` に修正
- DjangoのURLルーティングをPOSTメソッドに対応する形で定義
- like状態・カウントを含むJSONレスポンスを返却
- DOM操作でボタンの絵文字・カウント表示を即時反映

###テンプレート
1. いいね前の状態

![スクリーンショット 2025-04-18 16 12 31](https://github.com/user-attachments/assets/7e5295b2-2515-4f42-805a-09f0d0a58fa4)

2.いいね完了後

![スクリーンショット 2025-04-18 16 13 14](https://github.com/user-attachments/assets/743f8755-678d-499d-82e9-68fd3e84f652)

### 学び・気づき
- HTTP 405エラーは「URLは存在しているが、許可されていないメソッド」である点に注意
- ルーティング構造（アプリprefix + URL定義）の不一致がfetch側との整合性を崩す大きな原因になる

### 関連
Closed  #14
