### PR TITLE
異常系Case3 Ajax通信で未ログインユーザーがレビューにいいねしようとした場合に403を返すテストの作成

### DIFF
--- a/movies/tests/unit/test_review_like.py
+++ b/movies/tests/unit/test_review_like.py
@@ -73,6 +73,21 @@ class RevieLikeTest(TestCase):
         # DBからLikeが削除されたことを確認
         self.assertEqual(Like.objects.filter(user=self.userA, review=self.review).count(), 0)
 
+    # 未ログインユーザーがレビューにいいねを押した際にPOSTを403で拒否するかを検証（異常系）
+    def test_like_rejected_when_not_logged_in(self):
+        
+        # ajaxでポスト送信
+        response = self.client.post(
+            f"/movies/review_like/{self.review.id}/",
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        )
 
+        # いいねのポスト処理を拒否(403ステータスコード)
+        self.assertEqual(response.status_code, 403)
 
-    
+        # エラーメッセージがJSONで返っているかの検証（ユーザー目線での確認）
+        self.assertJSONEqual(response.content, {"error": "ログインが必要です"})
+
+        # いいねの記録データが作成されてないことの検証 
+        self.assertFalse(Like.objects.filter(review=self.review).exists())
+


### PR DESCRIPTION
## 概要  
未ログイン状態のユーザーがレビューに対して「いいね」操作を試みた場合、  
適切に403 Forbiddenが返ることを確認する異常系ユニットテストを追加しました。

## 実装内容  
- `ReviewLikeTest` クラスに異常系テストケース（未ログイン状態）を1件追加  
- Ajax経由のPOSTリクエストで403が返るかを確認  
- レスポンスのstatusとエラーメッセージ内容をアサート  

## テストケース一覧（TC03）

| テストID | 条件 | 期待される結果 |
|----------|------|----------------|
| TC03     | userBがログインしていない状態でAjax POST送信| ステータス403、エラーメッセージ返却確認 |

## 実行結果  
![スクリーンショット 2025-04-22 23 03 27](https://github.com/user-attachments/assets/d5240756-599c-4a05-95da-ca764201647e)

## 関連ISSUE
Closed #17 

