### PR TITLE
気分タグ機能の実装 (モデル設計)

### DIFF
--- a/movies/models.py
+++ b/movies/models.py
@@ -63,3 +63,8 @@ class Like(models.Model):
             models.UniqueConstraint(fields=["user", "review"], name="unique_user_review_like"),
         ]
 
+class Feel(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    movie = models.ForeignKey(UserMovieRecord, on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+

--- a/movies/models.py
+++ b/movies/models.py
@@ -67,8 +67,3 @@ class Like(models.Model):
 class Mood(models.Model):
     name = models.CharField(max_length=10)
 
-class Feel(models.Model):
-    user = models.ForeignKey(User, on_delete=models.CASCADE)
-    movie = models.ForeignKey(UserMovieRecord, on_delete=models.CASCADE)
-    created_at = models.DateTimeField(auto_now_add=True)
-

--- a/movies/models.py
+++ b/movies/models.py
@@ -7,23 +7,28 @@ class Genre(models.Model):
 
     def __str__(self):
         return self.name
+
+# ユーザーの感情をタグとして管理(#興奮, #新鮮, #癒された,#前向きになれた)
+class Mood(models.Model):
+    name = models.CharField(max_length=10)
         
-# ユーザーごとの映画鑑賞記録
 class UserMovieRecord(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE) 
     title = models.CharField(max_length=20)
     poster = models.ImageField(upload_to='posters/', null=True, blank=True)  #　映画ポスター画像（任意）
     poster_url = models.URLField(blank=True, null=True)  # APIから取得した画像URL用
-    date_watched = models.DateField()  
-    is_deleted = models.BooleanField(default=False)  # 論理削除フラグ（True: 非表示 / データはDBに残る）
     director = models.CharField(max_length=255, blank=True)
-    comment =  models.TextField(blank=True)  # 感想（任意）
+    genres = models.ManyToManyField(Genre)
     rating = models.IntegerField(default=3)
-    genres = models.ManyToManyField(Genre)  
+    mood = models.ForeignKey(Mood, on_delete=models.CASCADE, null=True, blank=True)
+    comment =  models.TextField(blank=True)  # 感想（任意）
+    date_watched = models.DateField()  
+    is_deleted = models.BooleanField(default=False)  # 論理削除フラグ（True: 非表示 / データはDBに残る）   
     tmdb_id = models.IntegerField(blank=True, null=True) #特定の映画情報を TMDb API から再取得するためのID
 
     def __str__(self):
         return f"{self.title} - {self.user.username}"
+
 
 # 映画に対するレビュー（感想投稿）
 class Review(models.Model):
@@ -62,8 +67,4 @@ class Like(models.Model):
         constraints =[
             models.UniqueConstraint(fields=["user", "review"], name="unique_user_review_like"),
         ]
-
-# ユーザーの感情をタグとして管理(#興奮, #新鮮, #癒された,#前向きになれた)
-class Mood(models.Model):
-    name = models.CharField(max_length=10)
 

--- a/movies/models.py
+++ b/movies/models.py
@@ -63,6 +63,10 @@ class Like(models.Model):
             models.UniqueConstraint(fields=["user", "review"], name="unique_user_review_like"),
         ]
 
+# ユーザーの感情をタグとして管理(#興奮, #新鮮, #癒された,#前向きになれた)
+class Mood(models.Model):
+    name = models.CharField(max_length=10)
+
 class Feel(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)
     movie = models.ForeignKey(UserMovieRecord, on_delete=models.CASCADE)


### PR DESCRIPTION
## 概要  
ユーザーが映画記録に対して感情を記録できるようにするため、感情タグ（mood）を管理するモデルを追加しました。

## 実装内容
- Mood モデルの追加（例：#癒された、#胸が熱くなった など）
     - name: CharField(max_length=10)

- UserMovieRecord に mood 外部キーを追加

- 感情は選択式タグとして保存され、1映画に1感情を登録する想定

## 動作確認手順
1. python manage.py makemigrations 

2. python manage.py migrate 

3. Django Admin にて Mood モデルの登録、UserMovieRecord への
    mood設定が可能であることを確認
    
4. ページを再読み込みしても状態が保持されていることを確認

## 今後の対応予定
- 感情タグをフォームから選択できるUIの追加

## 関連Issue
refs #20
