### PR TITLE
気分タグ機能の実装  (管理画面設計) 

### DIFF
--- a/movies/admin.py
+++ b/movies/admin.py
@@ -32,3 +32,8 @@ class ReviewAdmin(admin.ModelAdmin):
 @admin.register(Mood)
 class MoodAdmin(admin.ModelAdmin):
     list_display = ('name',)
+    
+    def __str__(self):
+        return self.name
+        
+

--- a/movies/admin.py
+++ b/movies/admin.py
@@ -4,7 +4,7 @@ from .models import UserMovieRecord, Genre, Review, Mood
 # 映画鑑賞記録の管理画面
 @admin.register(UserMovieRecord)
 class UserMovieRecordAdmin(admin.ModelAdmin):
-    list_display = ('title', 'user', 'date_watched', 'rating',)  
+    list_display = ('title', 'user', 'mood', 'date_watched', 'rating',) 
     search_fields = ('title', 'user__username',)  
     list_filter = ('date_watched', 'rating',)
 

--- a/movies/admin.py
+++ b/movies/admin.py
@@ -1,12 +1,12 @@
 from django.contrib import admin
-from .models import UserMovieRecord, Genre, Review
+from .models import UserMovieRecord, Genre, Review, Mood
 
 # 映画鑑賞記録の管理画面
 @admin.register(UserMovieRecord)
 class UserMovieRecordAdmin(admin.ModelAdmin):
-    list_display = ('title', 'user', 'date_watched', 'rating')  
-    search_fields = ('title', 'user__username')  
-    list_filter = ('date_watched', 'rating')
+    list_display = ('title', 'user', 'date_watched', 'rating',)  
+    search_fields = ('title', 'user__username',)  
+    list_filter = ('date_watched', 'rating',)
 
 # 映画ジャンルの管理画面
 @admin.register(Genre)
@@ -17,9 +17,9 @@ class GenreAdmin(admin.ModelAdmin):
 # 映画レビューの管理画面
 @admin.register(Review)
 class ReviewAdmin(admin.ModelAdmin):
-    list_display = ('movie', 'user', 'short_content', 'created_at')  
-    search_fields = ('movie__title', 'user__username', 'content')  
-    list_filter = ('movie', 'user', 'created_at')  
+    list_display = ('movie', 'user', 'short_content', 'created_at',)  
+    search_fields = ('movie__title', 'user__username', 'content',)  
+    list_filter = ('movie', 'user', 'created_at',)  
     ordering = ['-created_at']  # 新しいレビュー順で表示（デフォルトはID順のため変更）
 
     #レビューの冒頭25文字を表示（長い場合は省略）
@@ -27,3 +27,8 @@ class ReviewAdmin(admin.ModelAdmin):
         return obj.content[:25] + "..." if len(obj.content) > 25 else obj.content
 
     short_content.short_description = "レビュー内容"
+
+# ムード(映画鑑賞時感情記録)の管理画面
+@admin.register(Mood)
+class MoodAdmin(admin.ModelAdmin):
+    list_display = ('name',)

--- a/movies/models.py
+++ b/movies/models.py
@@ -23,7 +23,7 @@ class UserMovieRecord(models.Model):
     director = models.CharField(max_length=255, blank=True)
     genres = models.ManyToManyField(Genre)
     rating = models.IntegerField(default=3)
-    mood = models.ForeignKey(Mood, on_delete=models.CASCADE, null=True, blank=True)
+    mood = models.CharField(max_length=10, blank=True) 
     comment =  models.TextField(blank=True)  # 感想（任意）
     date_watched = models.DateField()  
     is_deleted = models.BooleanField(default=False)  # 論理削除フラグ（True: 非表示 / データはDBに残る）   

--- a/movies/models.py
+++ b/movies/models.py
@@ -11,6 +11,9 @@ class Genre(models.Model):
 # ユーザーの感情をタグとして管理(#興奮, #新鮮, #癒された,#前向きになれた)
 class Mood(models.Model):
     name = models.CharField(max_length=10)
+
+    def __str__(self):
+        return self.name  
         
 class UserMovieRecord(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE) 


### PR DESCRIPTION
## 概要  
UserMovieRecordの管理画面を修正し、感情タグ（mood）を自由入力できる形式に変更しました。
これにより、開発者が用意した感情選択肢から選ぶのではなく、
各ユーザーが映画に対して感じた印象を自由に入力・保存できるようになりました。

## 実装内容
- UserMovieRecordモデルのmoodフィールドをForeignKeyからCharFieldに変更

- 管理画面 (admin.py) のlist_displayを修正し、mood（自由入力された感情タグ）が一覧で確認できるよう対応

- makemigrations / migrate適用済み

## 動作確認手順
1. python manage.py makemigrations

2. python manage.py migrate

3. Django Adminにて、UserMovieRecord登録・編集画面で感情タグを自由に入力できることを確認

4. 映画一覧画面（管理画面）で、入力した感情タグが正しく表示されることを確認

5. ページ再読み込み後もデータが保持されることを確認

## テンプレート
1.管理画面で感情タグ入力欄に移動
![スクリーンショット 2025-04-27 14 06 44](https://github.com/user-attachments/assets/b67fca92-0ece-4e8d-a0e4-d782efced9ee)

2.感情タグの入力
![スクリーンショット 2025-04-27 14 09 07](https://github.com/user-attachments/assets/b0a1b3fa-c45f-4331-8f69-c8ea85e7d42d)

3.管理画面上でデータが反映されていることを確認
![スクリーンショット 2025-04-27 14 07 23](https://github.com/user-attachments/assets/eb2ab3af-848f-4bdd-ac89-69e9c61a0417)



## 今後の対応予定
- 感情タグをフォームから選択できるUIの追加

## 関連Issue
refs #20
