### PR TITLE
映画記録一覧・詳細画面に感情タグ（自由入力形式）を表示できるよう対応

### DIFF
--- a/templates/movies/home.html
+++ b/templates/movies/home.html
@@ -42,7 +42,7 @@
                           {% endfor %}
                         </p>
                         <p class="card-text">監督: {{ record.director }}</p>
-                        <p class="card-text">鑑賞日: {{ record.date_watched }}</p>
+                        <p class="card-text">ムード: {{ record.mood }}</p>
                         <p class="card-text">評価: 
                             {% if record.rating == 1 %}★☆☆☆☆
                             {% elif record.rating == 2 %}★★☆☆☆
@@ -52,6 +52,7 @@
                             {% endif %}
                         </p>
                         <p class="card-text">感想: {{ record.comment }}</p>
+                        <p class="card-text">鑑賞日: {{ record.date_watched }}</p>
                         <div class="text-center mt-auto">
                             <button type="button" class="btn-list" onclick="location.href='{% url 'movies:detail' record.pk %}'">詳細</button>
                             <button type="button" class="btn-edit" onclick="location.href='{% url 'movies:edit' record.pk %}'">編集</button>

--- a/templates/movies/movie_record_detail.html
+++ b/templates/movies/movie_record_detail.html
@@ -40,7 +40,6 @@
                     </p>
                     {% endif %}
 
-                    <p class="card-text">鑑賞日: {{ record.date_watched }}</p>
                     <p class="card-text">評価: 
                         {% if record.rating == 1 %}★☆☆☆☆
                         {% elif record.rating == 2 %}★★☆☆☆
@@ -50,9 +49,16 @@
                         {% endif %}
                     </p>
 
+                    {% if record.mood %}
+                        <p class="card-text">ムード: {{ record.mood }}</p>
+                    {% endif %}
+
                     {% if record.comment %}
                         <p class="card-text">感想: {{ record.comment }}</p>
                     {% endif %}
+
+                    <p class="card-text">鑑賞日: {{ record.date_watched }}</p>
+                    
                     <div class="text-center">
                         <a href="{% url 'movies:delete' pk=record.pk %}" class="btn btn-danger">削除</a>
                         <a href="{% url 'movies:review' record.pk %}" class="btn btn-primary">レビューを書く</a>


### PR DESCRIPTION
## 概要  
UserMovieRecordの管理画面を修正し、感情タグ（mood）を自由入力できる形式に変更しました。
これにより、各ユーザーが映画に対して感じた印象を自由に入力・保存できるようになりました。

## 実装内容
- 映画一覧・詳細テンプレートにて、record.moodを表示するコードを追加
- record.moodが存在する場合のみ表示する条件分岐を追加

## 動作確認手順
1. 感情タグが登録されている映画の場合、正しくmoodが表示されることを確認 
2. 感情タグ未登録の映画の場合、空のムード表示がされないことを確認 
3. ページ再読み込み後もデータが保持されていることを確認

## テンプレート
1. 映画一覧画面での感情タグの画面表示
<img width="1018" alt="スクリーンショット 2025-04-27 23 17 22" src="https://github.com/user-attachments/assets/5983dc75-47fc-4e23-9b8a-8e31e9c816ad" />

2. 映画詳細画面での感情タグの画面表示
<img width="1146" alt="スクリーンショット 2025-04-27 23 19 30" src="https://github.com/user-attachments/assets/a3b8b21a-5e95-4b74-b076-03e85de631aa" />


## 関連Issue
Closed #20
