### PR TITLE
感情タグ(mood)管理をManyToMany化、複数ムード登録・管理をできるように対応

### DIFF
--- a/movies/models.py
+++ b/movies/models.py
@@ -23,7 +23,7 @@ class UserMovieRecord(models.Model):
     director = models.CharField(max_length=255, blank=True)
     genres = models.ManyToManyField(Genre)
     rating = models.IntegerField(default=3)
-    mood = models.CharField(max_length=10, blank=True) 
+    mood = models.ManyToManyField(Mood, blank=True) 
     comment =  models.TextField(blank=True)  # 感想（任意）
     date_watched = models.DateField()  
     is_deleted = models.BooleanField(default=False)  # 論理削除フラグ（True: 非表示 / データはDBに残る）   

--- a/movies/views.py
+++ b/movies/views.py
@@ -1,5 +1,6 @@
 from django.views.generic import ListView, CreateView, DeleteView, UpdateView, DetailView
 from django.http import HttpResponseForbidden, JsonResponse
+from django.contrib.auth.mixins import LoginRequiredMixin, AccessMixin
 from django.urls import reverse_lazy
 from movies.models import UserMovieRecord, Genre, Mood, Review, Like
 from missions.models import Batch, UserBatch

--- a/movies/views.py
+++ b/movies/views.py
@@ -1,8 +1,7 @@
-from django.contrib.auth.mixins import LoginRequiredMixin, AccessMixin
 from django.views.generic import ListView, CreateView, DeleteView, UpdateView, DetailView
 from django.http import HttpResponseForbidden, JsonResponse
 from django.urls import reverse_lazy
-from movies.models import UserMovieRecord, Genre, Review, Like
+from movies.models import UserMovieRecord, Genre, Mood, Review, Like
 from missions.models import Batch, UserBatch
 from .forms import MovieRecordForm, MovieSearchForm, UserReviewForm
 from django.views import View
@@ -13,9 +12,21 @@ from .services import TmdbMovieService
 from datetime import date
 import requests
 
+
 # タイトル、ポスターURL、監督、ジャンルをAPIから取得し、UserMovieRecordに保存
 def create_movie_record(request):
     if request.method == "POST":
+        mood_text = request.POST.get("mood", "")
+        mood_tags = mood_text.replace("　", " ").split()  # 全角・半角スペース対応
+        mood_objs = []
+
+        for tag in mood_tags:
+            clean_tag = tag.lstrip("#")  # 先頭の # を削除（あれば）
+            if clean_tag:  # 空文字を除外
+                mood_obj, _ = Mood.objects.get_or_create(name=clean_tag)
+                mood_objs.append(mood_obj)
+
+
         record = UserMovieRecord.objects.create(
             title=request.POST["title"],
             poster_url=request.POST["poster"], 
@@ -25,6 +36,7 @@ def create_movie_record(request):
             date_watched=date.today(),
             user=request.user 
         )
+
         genre_names = request.POST["genres"].split(", ")
         genre_objs = []
         for name in genre_names:
@@ -32,7 +44,9 @@ def create_movie_record(request):
             genre_objs.append(genre)
         record.genres.set(genre_objs)
 
-        return redirect("movies:home")  
+        record.mood.set(mood_objs)
+
+        return redirect("movies:home")
 
     else:
         movie_id = request.GET.get("movie_id")
@@ -52,23 +66,20 @@ def create_movie_record(request):
 
         return render(request, "movies/movie_create.html", context)
 
-
 # 映画鑑賞記録一覧表示機能
 class UserMovieListView(LoginRequiredMixin, ListView):
     model = UserMovieRecord
     template_name = 'movies/home.html'
     context_object_name = 'records'
-    
 
     def get_queryset(self):
         return UserMovieRecord.objects.filter(user=self.request.user)
     
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
         form = MovieSearchForm(self.request.GET or None)
         context["form"] = form  
-        
+     
         if form.is_valid():
             query = form.cleaned_data["movie_title"]
             context["movies"] = TmdbMovieService.search(query) if query else []        

--- a/templates/movies/home.html
+++ b/templates/movies/home.html
@@ -44,7 +44,7 @@
                         <p class="card-text">監督: {{ record.director }}</p>
                         <p>ムード:
                             {% for mood in record.mood.all %}
-                                {{ mood.name }}{% if not forloop.last %}, {% endif %}
+                                #{{ mood.name }}{% if not forloop.last %}, {% endif %}
                             {% empty %}
                                 なし
                             {% endfor %}

--- a/templates/movies/home.html
+++ b/templates/movies/home.html
@@ -42,7 +42,13 @@
                           {% endfor %}
                         </p>
                         <p class="card-text">監督: {{ record.director }}</p>
-                        <p class="card-text">ムード: {{ record.mood }}</p>
+                        <p>ムード:
+                            {% for mood in record.mood.all %}
+                                {{ mood.name }}{% if not forloop.last %}, {% endif %}
+                            {% empty %}
+                                なし
+                            {% endfor %}
+                        </p>
                         <p class="card-text">評価: 
                             {% if record.rating == 1 %}★☆☆☆☆
                             {% elif record.rating == 2 %}★★☆☆☆

--- a/templates/movies/movie_create.html
+++ b/templates/movies/movie_create.html
@@ -19,6 +19,10 @@
   <input type="hidden" name="poster" value="{{ poster }}"> 
   <input type="hidden" name="director" value="{{ director }}"> 
   <input type="hidden" name="genres" value="{{ genres }}">
+
+  <!-- 感情タグ -->
+  <label for="mood">感情</label><br>
+  <textarea name="mood" id="mood" rows="2" cols="50" placeholder="「#」をつけて映画を見た印象を簡単に記録できます 例:「#迫力、#涙、#胸が熱くなった」"></textarea><br><br>
   
   <!-- 評価 -->
   <label for="rating">評価（1〜5）</label><br>

--- a/templates/movies/movie_record_detail.html
+++ b/templates/movies/movie_record_detail.html
@@ -49,9 +49,13 @@
                         {% endif %}
                     </p>
 
-                    {% if record.mood %}
-                        <p class="card-text">ムード: {{ record.mood }}</p>
-                    {% endif %}
+                    <p>ムード:
+                        {% for mood in record.mood.all %}
+                            {{ mood.name }}{% if not forloop.last %}, {% endif %}
+                        {% empty %}
+                             なし
+                        {% endfor %}
+                    </p>
 
                     {% if record.comment %}
                         <p class="card-text">感想: {{ record.comment }}</p>


### PR DESCRIPTION
## 概要  
UserMovieRecordの感情タグ（mood）表示形式を改善し、一覧・詳細画面にてハッシュタグ（#）形式で視認できるように修正しました。
これにより、各映画に紐づいた気分タグが視覚的に区切られて表示され、将来的なタグ検索・フィルタ機能への導線としても活用しやすくなります。

## 実装内容
- 一覧テンプレート（home.html）で `#{{ mood.name }}` 形式に修正

- 詳細テンプレート（movie_record_detail.html）でも同様にハッシュ表示へ変更

- ムードが空の場合は「なし」と表示されるロジックは維持

## 動作確認手順
1. 複数ムードが登録されている映画が `#`付きで表示されることを確認

2. ムードが未登録の場合、「なし」と表示されることを確認

3. テンプレート全体のレイアウト崩れがないことを確認

## スクリーンショット

1. 映画一覧でのハッシュ付きムード表示
<img width="1037" alt="スクリーンショット 2025-05-08 23 22 15" src="https://github.com/user-attachments/assets/ebdff9be-47cd-4208-a0eb-cbe82e1f5e15" />


2. 映画詳細でのハッシュ付きムード表示
<img width="1173" alt="スクリーンショット 2025-05-08 23 23 05" src="https://github.com/user-attachments/assets/9f191374-a902-4ff0-b055-cea766333549" />


## 関連Issue
Closes # 24
