### PR TITLE
感情タグによる映画検索機能の追加と整形処理の共通化による不一致不具合の修正

### DIFF
--- a/movies/urls.py
+++ b/movies/urls.py
@@ -7,6 +7,7 @@ app_name = 'movies'
 urlpatterns = [
     path('home/', UserMovieListView.as_view(),name='home'),
     path('search/', MovieSearchView.as_view(), name='movie_search'),
+    path('mood_search/', UserMovieListView.as_view(), name='mood_search'),
     path('movie_create/', views.create_movie_record, name='movie_create'),
     path('detail/<int:pk>/',MovieRecordDetailView.as_view(), name='detail'),
     path('review/<int:pk>/', ReviewPageView.as_view(), name='review'),

--- a/movies/views.py
+++ b/movies/views.py
@@ -73,8 +73,14 @@ class UserMovieListView(LoginRequiredMixin, ListView):
     template_name = 'movies/home.html'
     context_object_name = 'records'
 
+    #感情タグの検索フィルタリング
     def get_queryset(self):
-        return UserMovieRecord.objects.filter(user=self.request.user)
+        qs = UserMovieRecord.objects.filter(user=self.request.user)
+        mood = self.request.GET.get("mood")
+        if mood:
+            mood = mood.lstrip("#")
+            qs = qs.filter(mood__name__in=[mood])
+        return qs
     
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/templates/movies/home.html
+++ b/templates/movies/home.html
@@ -10,6 +10,11 @@
         <button type="submit">検索</button>
     </form>
 
+    <!-- 感情タグ検索セクション -->
+    <form method="get" action="{% url 'movies:mood_search' %}">
+        <input type="text" name="mood" placeholder="記録として残した感情タグを入力「例: #迫力、#泣ける」">
+        <button type="submit" class="btn-light">検索</button>
+    </form>
 
     <div class="container my-1">
         <section class="jumbotron text-center">


### PR DESCRIPTION
## 概要  
感情タグ（mood）による映画鑑賞記録の検索・フィルタ機能を追加しました。
併せて、登録時および検索時にタグ整形処理が統一されていなかった問題を修正し、 検索結果の一貫性と正確性を改善しました。

## 背景
感情タグ検索時、 #興奮, #新鮮のように複数タグを登録しても、一部のタグ（例：#興奮）では検索時に一致せず、正しくヒットしない不具合がありました。 これは、登録時に末尾のカンマ・空白などが残ったまま保存され、文字列が検索時と一致しなかったことが原因です。

-  再現例
1. トップガン マーヴェリック → タグ: #涙, #興奮
2. インセプション → タグ: #興奮, #新鮮 → #興奮 で検索しても、トップガン マーヴェリックのみヒット
　
　  原因: ‘#興奮,’ でデータ登録されていたため、#興奮という検索ではヒットしなかった
　  
##  実装内容
 - タグ整形処理 parse_and_get_mood_objects() を新規実装 　
    (半角・全角スペース、読点、カンマ、先頭の # を除去・分割・正規化)
 - 上記処理を登録・検索処理の両方に適用し、表記ゆれのない一致を実現
 - UserMovieListView.get_queryset() に整形済みのタグリストを使用
 - distinct() による重複排除を追加
 
 ##テンプレート
 1. #興奮で検索 (興奮でも対応可能)
<img width="269" alt="スクリーンショット 2025-05-14 13 53 07" src="https://github.com/user-attachments/assets/19abe45c-6ee0-4306-b639-3d0d3cb9265f" />

2. 検索結果パス
<img width="655" alt="スクリーンショット 2025-05-14 13 53 19" src="https://github.com/user-attachments/assets/4b97250c-04e5-4747-b6f7-4aa867123ef8" />

3. 検索結果
     1.トップガンマーベリック
<img width="1076" alt="スクリーンショット 2025-05-14 13 52 19" src="https://github.com/user-attachments/assets/b4bb698a-a70c-4be9-b295-bad33dbdf660" />

     2.インセプション
<img width="1041" alt="スクリーンショット 2025-05-14 13 52 32" src="https://github.com/user-attachments/assets/6d9cab04-b731-49ba-91f5-05c80211c4e5" />

 ## 確認事項
 - 複数タグで登録・検索しても全件ヒットする
 - 空文字・無効タグ（スペースのみ）で検索してもエラーが出ない
 -  登録・検索の整形ロジックが完全に一致している
  - 表示上、正しい映画のみが抽出されている


