### PR TITLE
感情アーカイブページの作成と導線追加

### DIFF
--- a/movies/urls.py
+++ b/movies/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import UserMovieListView, MovieSearchView, MovieRecordDetailView, ReviewPageView, ThanksPageView, ReviewLikeView, MovieRecordCreateView, MovieRecordDeleteView, MovieRecordEditView
+from .views import UserMovieListView, MovieSearchView, MovieRecordDetailView, MoodArchiveView, ReviewPageView, ThanksPageView, ReviewLikeView, MovieRecordCreateView, MovieRecordDeleteView, MovieRecordEditView
 from . import views
 
 app_name = 'movies'
@@ -8,6 +8,7 @@ urlpatterns = [
     path('home/', UserMovieListView.as_view(),name='home'),
     path('search/', MovieSearchView.as_view(), name='movie_search'),
     path('mood_search/', UserMovieListView.as_view(), name='mood_search'),
+    path('mood_archive/<str:mood_name>/',MoodArchiveView.as_view(), name='mood_archive'),
     path('movie_create/', views.create_movie_record, name='movie_create'),
     path('detail/<int:pk>/',MovieRecordDetailView.as_view(), name='detail'),
     path('review/<int:pk>/', ReviewPageView.as_view(), name='review'),

--- a/movies/views.py
+++ b/movies/views.py
@@ -19,6 +19,13 @@ def parse_and_get_mood_objects(mood_text):
     tags = [tag.strip().lstrip("#") for tag in raw if tag.strip()]
     return [Mood.objects.get_or_create(name=tag)[0] for tag in tags]
 
+#特定の感情アーカイブページへのアクセス設定 (該当するページがなければホームページにリダイレクト)
+def redirect_to_mood_archive(request):
+    mood = request.GET.get("mood", "").strip().lstrip("#")
+    if mood:
+        return redirect("movies:mood_archive", mood_name=mood)  
+    return redirect("movies:home")
+
 # タイトル、ポスターURL、監督、ジャンルをAPIから取得し、UserMovieRecordに保存
 def create_movie_record(request):
     if request.method == "POST":

--- a/templates/movies/mood_archive.html
+++ b/templates/movies/mood_archive.html
@@ -1,0 +1,63 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}{{ mood_name }}のアーカイブ一覧{% endblock %}
+
+{% block content %}
+
+<div class="container">
+  <h2 class="text-center my-4">「{{ mood_name }}」の映画一覧</h2>
+
+  {% for record in mood_archive %}
+    <div class="card mb-4 shadow-sm">
+      <div class="row g-0">
+        <!-- ポスター -->
+        <div class="col-md-4">
+          {% if record.poster %}
+            <img src="{{ record.poster.url }}" class="img-fluid rounded-start" alt="{{ record.title }}">
+          {% elif record.poster_url %}
+            <img src="{{ record.poster_url }}" class="img-fluid rounded-start" alt="{{ record.title }}">
+          {% else %}
+            <img src="{% static 'images/default_poster.jpg' %}?v={{ STATIC_VERSION }}" class="img-fluid rounded-start" alt="No image">
+          {% endif %}
+        </div>
+
+        <!-- 映画情報 -->
+        <div class="col-md-8">
+          <div class="card-body">
+            <h5 class="card-title">{{ record.title }}</h5>
+            <p class="card-text text-muted">ジャンル: 
+              {% for genre in record.genres.all %}
+                {{ genre.name }}{% if not forloop.last %}, {% endif %}
+              {% endfor %}
+            </p>
+            <p class="card-text">監督: {{ record.director }}</p>
+            <p class="card-text">ムード: 
+              {% for mood in record.mood.all %}
+                #{{ mood.name }}{% if not forloop.last %}, {% endif %}
+              {% empty %} なし
+              {% endfor %}
+            </p>
+            <p class="card-text">評価: 
+              {% if record.rating == 1 %}★☆☆☆☆
+              {% elif record.rating == 2 %}★★☆☆☆
+              {% elif record.rating == 3 %}★★★☆☆
+              {% elif record.rating == 4 %}★★★★☆
+              {% else %}★★★★★
+              {% endif %}
+            </p>
+            <p class="card-text">感想: {{ record.comment }}</p>
+            <p class="card-text"><small class="text-muted">鑑賞日: {{ record.date_watched }}</small></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% empty %}
+    <p class="text-center text-muted">該当する映画記録が見つかりませんでした。</p>
+  {% endfor %}
+
+  <div class="text-center mt-4">
+    <a href="{% url 'movies:movie_search' %}" class="btn btn-secondary">ホーム画面に戻る</a>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## 概要  
ユーザーが自身の「感情（mood）」を軸に過去の映画記録を振り返れるよう、感情ごとのアーカイブページ /moods/<mood_name>/ を実装しました。
加えて、感情タグを受け取り該当アーカイブにリダイレクトするビュー redirect_to_mood_archive() を追加し、UI上の検索やリンクから自然に遷移できる導線も整備しています。

## 背景
MovieLogでは感情タグ付きで映画を記録できるようにしていましたが、
「感情ごとに記録を振り返る」体験は一覧画面上では伝わりづらく、
「今日は#前向きになれる映画を見たい」といった気分に応じた回想体験に結びつきにくいと考えました。
また、検索機能からの導線も不十分で、検索→結果一覧→対象感情の再絞り込みの導線が必要だと感じました。
そのような経緯より感情アーカイブページの動線の作成を進めました。

## 実装内容
- MoodArchiveView（ListView）を追加
       - URL /moods/<mood_name>/ にアクセス時、該当感情タグが付いた UserMovieRecord をフィルタ表示
       - contextに mood_name を渡すことで、画面上部に現在の感情を見出しとして表示

- redirect_to_mood_archive() ビューを新規追加
       - ?mood=興奮 などのパラメータを受け取り、該当する感情アーカイブページにリダイレクト
       - パラメータが空・不正な場合は /movies/home にフォールバック（UXエラー回避）


## テンプレート
1. ルーティング確認（/movies/mood_archive/興奮）
<img width="391" alt="スクリーンショット 2025-05-16 22 47 47" src="https://github.com/user-attachments/assets/82c837e2-d8d1-4e6a-8dd1-efc513a1c10f" />

2. 「トップガン マーヴェリック」表示内容
<img width="1249" alt="スクリーンショット 2025-05-16 22 46 07" src="https://github.com/user-attachments/assets/12af0970-7015-4c0b-9b7c-33a0eeebbbbe" />

3. 「インセプション」表示内容
<img width="1202" alt="スクリーンショット 2025-05-16 22 33 00" src="https://github.com/user-attachments/assets/03b0aa03-1ccb-48df-a3b8-d11dff5d2c22" />

## 関連Issue
Closed # 28
