### PR TITLE
fix:バッチ一覧リストテンプレート名修正 #54

### DIFF
--- a/missions/views.py
+++ b/missions/views.py
@@ -46,8 +46,9 @@ class UserMissionProgressView(LoginRequiredMixin, ListView):
 # バッチ一覧表示リストビュー
 class BatchListTemplateView(LoginRequiredMixin, View):
     def get(self, request, *args, **kwargs):
-        return render(request, "missions/batch_list.html")
+        return render(request, "missons/user_batch_list.html")
     
+
 # バッチ一覧表示リストビュー
 class BatchListView(View):
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## 概要
fix/54-batch-list ブランチには、#50・#52 の不要なコミットが混在しており
安全にマージできる状態ではなかったため、main からクリーンな作業用ブランチ（pick/54-badge-template）を新規作成し、#54 のコミット（420446f）のみを cherry-pick しました。
